### PR TITLE
Fix i18n

### DIFF
--- a/sources/config.php
+++ b/sources/config.php
@@ -1,3 +1,4 @@
+
 <?php
 
 /* Wifi Hotspot app for YunoHost 
@@ -17,6 +18,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+
 
 // Limonade configuration
 function configure() {
@@ -39,26 +42,37 @@ function T_($string) {
 
 // Before routing
 function before($route) {
-     /**
+    $lang_mapping = array(
+       'fr' => 'fr_FR'
+    );
+
+   /**
      * * Locale
      * */
     if (!isset($_SESSION['locale'])) {
         $locale = explode(',',$_SERVER['HTTP_ACCEPT_LANGUAGE']);
         $_SESSION['locale'] = strtolower(substr(chop($locale[0]),0,2));
     }
+    $lang = $_SESSION['locale'];
+    // Convert simple language code into full language code
+    if (array_key_exists($lang, $lang_mapping)) {
+        $lang = $lang_mapping[$lang];
+    }
+    $lang = $lang.'.utf8';
     $textdomain="localization";
-    putenv('LANGUAGE='.$_SESSION['locale']);
-    putenv('LANG='.$_SESSION['locale']);
-    putenv('LC_ALL='.$_SESSION['locale']);
-    putenv('LC_MESSAGES='.$_SESSION['locale']);
-    setlocale(LC_ALL,$_SESSION['locale']);
-    setlocale(LC_CTYPE,$_SESSION['locale']);
-    $locales_dir = dirname(__FILE__).'/../i18n';
+
+    putenv('LANGUAGE='.$lang);
+    putenv('LANG='.$lang);
+    putenv('LC_ALL='.$lang);
+    putenv('LC_MESSAGES='.$lang);
+    setlocale(LC_ALL,$lang);
+    setlocale(LC_CTYPE,$lang);
+    $locales_dir = dirname(__FILE__).'/i18n';
     bindtextdomain($textdomain,$locales_dir);
     bind_textdomain_codeset($textdomain, 'UTF-8');
     textdomain($textdomain);
     // Set the $locale variable in template
-    set('locale', $_SESSION['locale']);
+    set('locale', $lang);
 }
 
 // After routing


### PR DESCRIPTION
Hi!

Fix https://github.com/labriqueinternet/hotspot_ynh/issues/7.

- Fix i18n path (from ```/../i18n``` to ```/i18n```)
- Add language code mapping. For instance ```fr``` is not recolonized as a language. In contrast ```fr_fr``` is recolonized as a language
- Add encoding to the language code.
