### PR TITLE
Ajout check_process

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,0 +1,25 @@
+;; Test complet
+	auto_remove=1
+	; Manifest
+		domain="domain.tld"	(DOMAIN)
+		path="/path"	(PATH)
+		wifi_ssid="myNeutralNetwork"
+		wifi_passphrase="VhegT8oev0jZI"	(PASSWORD)
+		firmware_nonfree="yes"
+	; Checks
+		pkg_linter=1
+		setup_sub_dir=1
+		setup_root=1
+		setup_nourl=0
+		setup_private=0
+		setup_public=0
+		upgrade=1
+		backup_restore=1
+		multi_instance=0
+		wrong_user=0
+		wrong_path=1
+		incorrect_path=1
+		corrupt_source=0
+		fail_download_source=0
+		port_already_use=0
+		final_path_already_use=0


### PR DESCRIPTION
Ajout du fichier check_process pour l'intégration continue.
Le package ne peut pas être testé correctement sans ce fichier.