### PR TITLE
Force firmware_nonfree to no on armbian

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -66,6 +66,14 @@ ynh_webpath_available "$domain" "$path_url"
 # Register (book) web path
 ynh_webpath_register "$app" "$domain" "$path_url"
 
+# If we're on armbian, force $firmware_nonfree
+# because armbian-firmware conflicts with the non-free packages ...
+if dpkg --list | grep -q armbian-firmware; then
+  echo "You are running Armbian and non-free firmware are known to conflict with armbian-firwmare. " >&2
+  firmware_nonfree="no"
+  echo "Variable firmware_non_free has been forced to 'no'" >&2
+fi
+
 #=================================================
 # STORE SETTINGS FROM MANIFEST
 #=================================================


### PR DESCRIPTION
This is a fix for https://github.com/labriqueinternet/hotspot_ynh/issues/30

It is too easy to forget to set this setting to no when running an internet cube install using the armbian images and this miserably breaks the whole installation ...

N.B. : I did not actually test it though ...