### PR TITLE
Buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 This YunoHost app is a part of the "[La Brique Internet](http://labriqueinter.net)" project but can be used independently.
 
 ## Overview
-
 Hotspot Wi-Fi app for [YunoHost](http://yunohost.org/).
 
 * Broadcast your own Wi-Fi internet access in addition to your self-hosted web services.
@@ -21,7 +20,7 @@ Hotspot Wi-Fi app for [YunoHost](http://yunohost.org/).
 * Automatic clients configuration (IPv6 with SLAAC/DHCPv6 and IPv4 with DHCPv4)
 * Set an IPv6 from your delegated prefix (*prefix::42*) on the server, to use for the AAAA records
 
-## Screenshot
+## Screenshots
 
 ![Screenshot of the web interface](https://raw.githubusercontent.com/labriqueinternet/hotspot_ynh/master/screenshot.png)
 

--- a/check_process
+++ b/check_process
@@ -14,6 +14,7 @@
 		setup_public=0
 		upgrade=1
 		upgrade=1	from_commit=546fd17712c7a9df428a4f26e7f8e4394884aaaf
+		upgrade=1	from_commit=ec919eb58fdc9c358ddbe17558874ae968a7f527
 		backup_restore=1
 		multi_instance=0
 		incorrect_path=1
@@ -34,3 +35,5 @@
 	; commit=546fd17712c7a9df428a4f26e7f8e4394884aaaf
 		name=29 Jan 2019
 		manifest_arg=domain=DOMAIN&path=PATH&wifi_ssid="myNeutralNetwork"&wifi_passphrase=PASSWORD&firmware_nonfree="no"
+	; commit=ec919eb58fdc9c358ddbe17558874ae968a7f527
+		name=3 Sep 2019 / 1.2.0

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -26,16 +26,15 @@ location __PATH__/ {
     rewrite ^ https://$server_name$request_uri? permanent;
   }
 
+  index index.php;
+  
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 10G;
 
-  index index.php;
-
   try_files $uri $uri/ index.php;
-
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-    fastcgi_pass unix:/var/run/php/php7.0-fpm-__NAME__.sock;
+    fastcgi_pass unix:/var/run/php/php__PHPVERSION__-fpm-__NAME__.sock;
 
     fastcgi_index index.php;
     include fastcgi_params;

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -33,7 +33,7 @@ group = __USER__
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php/php7.0-fpm-__NAMETOCHANGE__.sock
+listen = /var/run/php/php__PHPVERSION__-fpm-__NAMETOCHANGE__.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
@@ -428,4 +428,3 @@ php_value[max_execution_time] = 600
 ; php_admin_value[max_input_time] = 300
 ; php_admin_value[memory_limit] = 256M
 ; php_admin_flag[short_open_tag] = On
-

--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -278,7 +278,7 @@ if [ "$1" != restart ]; then
   # Restart php7.0-fpm at the first start (it needs to be restarted after the slapd start)
   if [ ! -e /tmp/.ynh-hotspot-boot ]; then
     touch /tmp/.ynh-hotspot-boot
-    systemctl restart php7.0-fpm
+    systemctl restart php__PHPVERSION__-fpm
   fi
 
   # Variables

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us debug, it would be nice to fill the template as much as you can to help us, help you and help us all.
+
+---
+
+**How to post a meaningful bug report**
+1. *Read this whole template first.*
+2. *Determine if you are on the right place:*
+   - *If you were performing an action on the app from the webadmin or the CLI (install, update, backup, restore, change url...), you are on the right place!*
+   - *Otherwise, the issue may be due to hotspot itself. Refer to its documentation or repository for help.*
+   - *If you have a doubt, post here, we will figure it out together.*
+3. *Delete the italic comments as you write over them below, and remove this guide.*
+--- 
+
+**Describe the bug**
+*A clear and concise description of what the bug is.*
+
+**Versions**
+- Hardware: *VPS bought online / Old laptop or computer / Raspberry Pi at home / Internet Cube with VPN / Other ARM board / ...*
+- YunoHost version: x.x.x
+- I have access to my server: *Through SSH | through the webadmin | direct access via keyboard / screen | ...*
+- Are you in a special context or did you perform some particular tweaking on your YunoHost instance ?: *no / yes*
+  - If yes, please explain:
+- Using, or trying to install package version/branch:
+- If upgrading, current package version: *can be found in the admin, or with `yunohost app info $app_id`*
+
+**To Reproduce**
+*Steps to reproduce the behavior.*
+- *If you performed a command from the CLI, the command itself is enough. For example:*
+    ```sh
+    sudo yunohost app install hotspot
+    ```
+- *If you used the webadmin, please perform the equivalent command from the CLI first.*
+- *If the error occurs in your browser, explain what you did:*
+   1. *Go to '...'*
+   2. *Click on '....'*
+   3. *Scroll down to '....'*
+   4. *See error*
+
+**Expected behavior**
+*A clear and concise description of what you expected to happen. You can remove this section if the command above is enough to understand your intent.*
+
+**Logs**
+*After a failed command, YunoHost makes the log available to you, but also to others, thanks to `yunohost log display [log name] --share`. The actual command, with the correct log name, is displayed at the end of the failed attempt in the CLI. Execute it and copy here the share link it outputs.*
+*If applicable and useful, add screenshots to help explain your problem.*

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "fr": "Hotspot Wifi"
   },
   "url": "https://github.com/labriqueinternet/hotspot_ynh",
-  "version": "1.2.0",
+  "version": "1.2.0~ynh2",
   "license": "AGPL-3.0",
   "maintainer": {
     "name": "Julien Vaubourg",

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "url": "http://julien.vaubourg.com"
   },
   "requirements": {
-    "yunohost": ">= 3.2.0"
+    "yunohost": ">= 3.5.0"
   },
   "multi_instance": false,
   "services": [

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,18 @@
+## Problem
+- *Description of why you made this PR*
+
+## Solution
+- *And how do you fix that problem*
+
+## PR Status
+- [ ] Code finished.
+- [ ] Tested with Package_check.
+- [ ] Fix or enhancement tested.
+- [ ] Upgrade from last version tested.
+- [ ] Can be reviewed and tested.
+
+## Package_check results
+---
+*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*
+
+[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/hotspot_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/hotspot_ynh%20PR-NUM-%20(USERNAME)/)  

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
-#
-# Common variables
-#
+#=================================================
+# COMMON VARIABLES
+#=================================================
 
-pkg_dependencies="php5-fpm sipcalc hostapd iptables iw dnsmasq"
+pkg_dependencies="sipcalc hostapd iptables iw dnsmasq"
 nonfree_packages="firmware-linux-free firmware-linux-nonfree firmware-atheros firmware-realtek firmware-ralink firmware-libertas atmel-firmware zd1211-firmware"
 free_packages="firmware-linux-free"
+
+#=================================================
+# PERSONAL HELPERS
+#=================================================
+
+#=================================================
+# EXPERIMENTAL HELPERS
+#=================================================
+
+#=================================================
+# FUTURE OFFICIAL HELPERS
+#=================================================

--- a/scripts/backup
+++ b/scripts/backup
@@ -6,6 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+#Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
@@ -19,74 +20,73 @@ ynh_abort_if_errors
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_print_info "Loading installation settings..."
+ynh_print_info --message="Loading installation settings..."
 
 app=$YNH_APP_INSTANCE_NAME
 
-final_path=$(ynh_app_setting_get $app final_path)
-domain=$(ynh_app_setting_get $app domain)
-firmware_nonfree=$(ynh_app_setting_get $app firmware_nonfree)
-service_name=$(ynh_app_setting_get $app service_name)
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+domain=$(ynh_app_setting_get --app=$app --key=domain)
+firmware_nonfree=$(ynh_app_setting_get --app=$app --key=firmware_nonfree)
+service_name=$(ynh_app_setting_get --app=$app --key=service_name)
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
-# STANDARD BACKUP STEPS
+# DECLARE DATA AND CONF FILES TO BACKUP
+#=================================================
+ynh_print_info --message="Declaring files to be backed up..."
+
 #=================================================
 # BACKUP THE APP MAIN DIR
 #=================================================
-ynh_print_info "Backing up the main app directory..."
 
-ynh_backup "$final_path"
+ynh_backup --src_path="$final_path"
 
 if [[ $firmware_nonfree -eq 0 ]]; then
-  ynh_backup "/lib/firmware/htc_7010.fw"
-  ynh_backup "/lib/firmware/htc_9271.fw"
+	ynh_backup --src_path="/lib/firmware/htc_7010.fw"
+	ynh_backup --src_path="/lib/firmware/htc_9271.fw"
 fi
 
-ynh_backup "/etc/sudoers.d/${app}_ynh"
+ynh_backup --src_path="/etc/sudoers.d/${app}_ynh"
 
-ynh_backup "/usr/local/bin/iw_multissid"
-ynh_backup "/usr/local/bin/iw_devices"
-ynh_backup "/usr/local/bin/iw_ssids"
-ynh_backup "/usr/local/bin/ipv6_expanded"
-ynh_backup "/usr/local/bin/ipv6_compressed"
+ynh_backup --src_path="/usr/local/bin/iw_multissid"
+ynh_backup --src_path="/usr/local/bin/iw_devices"
+ynh_backup --src_path="/usr/local/bin/iw_ssids"
+ynh_backup --src_path="/usr/local/bin/ipv6_expanded"
+ynh_backup --src_path="/usr/local/bin/ipv6_compressed"
 
 for FILE in $(ls /etc/hostapd/hostapd.conf{.tpl?,} 2>/dev/null)
 do
-    ynh_backup "$FILE"
+	ynh_backup --src_path="$FILE"
 done
-ynh_backup "/etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl"
-ynh_backup "/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
+ynh_backup --src_path="/etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl"
+ynh_backup --src_path="/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
 
-ynh_backup  "/usr/local/bin/$service_name"
+ynh_backup --src_path="/usr/local/bin/$service_name"
 
-ynh_backup "/etc/init.d/hostapd"
-
+ynh_backup --src_path="/etc/init.d/hostapd"
 
 #=================================================
 # BACKUP THE NGINX CONFIGURATION
 #=================================================
-ynh_print_info "Backing up nginx web server configuration..."
 
-ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
+ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
 # BACKUP THE PHP-FPM CONFIGURATION
 #=================================================
-ynh_print_info "Backing up php-fpm configuration..."
 
-ynh_backup "/etc/php/7.0/fpm/pool.d/$app.conf"
+ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 
 #=================================================
 # SPECIFIC BACKUP
 #=================================================
 # BACKUP SYSTEMD
 #=================================================
-ynh_print_info "Backing up systemd configuration..."
 
-ynh_backup "/etc/systemd/system/$service_name.service"
+ynh_backup --src_path="/etc/systemd/system/$service_name.service"
 
 #=================================================
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info "Backup script completed for $app. (YunoHost will then actually copy those files to the archive)."
+ynh_print_info --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)."

--- a/scripts/install
+++ b/scripts/install
@@ -37,7 +37,6 @@ ynh_abort_if_errors
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
-# Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 wifi_ssid=$YNH_APP_ARG_WIFI_SSID
@@ -52,17 +51,13 @@ service_name='ynh-hotspot'
 #=================================================
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
 #=================================================
-ynh_print_info "Validating installation parameters..."
+ynh_script_progression --message="Validating installation parameters..."
 
-# Check destination directory
-final_path="/var/www/$app"
-test ! -e "$final_path" || ynh_die "This path already contains a folder"
-
-# Normalize the url path syntax
-path_url=$(ynh_normalize_url_path $path_url)
+final_path=/var/www/$app
+test ! -e "$final_path" || ynh_die --message="This path already contains a folder"
 
 # Register (book) web path
-ynh_webpath_register $app $domain $path_url
+ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 
 # If we're on armbian, force $firmware_nonfree
 # because armbian-firmware conflicts with the non-free packages ...
@@ -80,18 +75,18 @@ fi
 
 # Check arguments
 if [[ -z $wifi_ssid || -z $wifi_passphrase ]]; then
-  ynh_die "Your Wifi Hotspot needs a name and a password"
+  ynh_die --message="Your Wifi Hotspot needs a name and a password"
 fi
 
 # Check passphrase length
 wifi_passphrase_length="$(echo -n "${wifi_passphrase}" | wc -c)"
 if [[ $wifi_passphrase_length -lt 8 || $wifi_passphrase_length -gt 63 ]]; then
-  ynh_die "Your password must from 8 to 63 characters (WPA2 passphrase)"
+  ynh_die --message="Your password must from 8 to 63 characters (WPA2 passphrase)"
 fi
 
 # Check no special characters are present in the passphrase
 if [[ $wifi_passphrase =~ [^[:print:]] ]]; then
-  ynh_die "Only printable ASCII characters are permitted in your password (WPA2 passphrase)"
+  ynh_die --message="Only printable ASCII characters are permitted in your password (WPA2 passphrase)"
 fi
 
 #=================================================
@@ -103,20 +98,19 @@ source ./prerequisites
 #=================================================
 # STORE SETTINGS FROM MANIFEST
 #=================================================
-ynh_print_info "Storing installation settings..."
+ynh_script_progression --message="Storing installation settings..."
 
-ynh_app_setting_set "$app" domain "$domain"
-ynh_app_setting_set "$app" final_path "$final_path"
-ynh_app_setting_set "$app" wifi_ssid "$wifi_ssid"
-ynh_app_setting_set "$app" wifi_passphrase "$wifi_passphrase"
-ynh_app_setting_set "$app" firmware_nonfree "$firmware_nonfree"
+ynh_app_setting_set --app=$app --key=domain --value="$domain"
+ynh_app_setting_set --app=$app --key=wifi_ssid --value="$wifi_ssid"
+ynh_app_setting_set --app=$app --key=wifi_passphrase --value="$wifi_passphrase"
+ynh_app_setting_set --app=$app --key=firmware_nonfree --value="$firmware_nonfree"
 
 #=================================================
 # STANDARD MODIFICATIONS
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_print_info "Configuring firewall..."
+ynh_script_progression --message="Configuring firewall..."
 
 # Update firewall for DHCP
 ynh_exec_warn_less yunohost firewall allow --no-upnp --ipv6 UDP 547
@@ -125,6 +119,7 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP 67
 #=================================================
 # INSTALL NONFREE FIRWARE IF REQUESTED
 #=================================================
+ynh_script_progression --message="Installing firmware..."
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -135,11 +130,9 @@ if [[ $firmware_nonfree -eq 1 ]]; then
   if ! grep -q non-free /etc/apt/sources.list ; then
     sed '/debian/{s/main/& non-free/}' -i /etc/apt/sources.list
   fi
-
   packages=$nonfree_packages
 else
   packages=$free_packages
-
   # Extract from http://packages.trisquel.info/toutatis-updates/open-ath9k-htc-firmware
   # https://www.fsf.org/news/ryf-certification-thinkpenguin-usb-with-atheros-chip
   # https://wiki.debian.org/ath9k_htc/open_firmware
@@ -151,14 +144,14 @@ fi
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
-ynh_print_info "Installing dependencies..."
+ynh_script_progression --message="Creating a MySQL database..."
 
 ynh_install_app_dependencies "$pkg_dependencies" "$packages"
 
 #=================================================
 # NGINX CONFIGURATION
 #=================================================
-ynh_print_info "Configuring nginx web server..."
+ynh_script_progression --message="Configuring nginx web server..."
 
 # Create a dedicated nginx config
 ynh_add_nginx_config
@@ -166,26 +159,28 @@ ynh_add_nginx_config
 #=================================================
 # CREATE DEDICATED USER
 #=================================================
-ynh_print_info "Configuring system user..."
+ynh_script_progression --message="Configuring system user..."
 
 # Create a system user
-ynh_system_user_create $app
+ynh_system_user_create --username=$app
 
 # Ensure the system user has enough sudo permissions
 install -b -o root -g root -m 0440 ../conf/sudoers.conf /etc/sudoers.d/${app}_ynh
-ynh_replace_string "__HOTSPOT_SYSUSER__" "${app}" /etc/sudoers.d/${app}_ynh
+ynh_replace_string --match_string="__HOTSPOT_SYSUSER__" --replace_string="${app}" --target_file="/etc/sudoers.d/${app}_ynh"
 
 #=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
-ynh_print_info "Configuring php-fpm..."
+ynh_script_progression --message="Configuring php-fpm..."
 
 # Create a dedicated php-fpm config
 ynh_add_fpm_config
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # INSTALL CUSTOM SCRIPTS
 #=================================================
+ynh_script_progression --message="Installing custom script..."
 
 install -o root -g root -m 0755 ../conf/iw_multissid /usr/local/bin/
 install -o root -g root -m 0755 ../conf/iw_devices /usr/local/bin/
@@ -210,33 +205,34 @@ fi
 
 wifi_device=$(bash ../conf/iw_devices | awk -F\| '{ print $1 }')
 
-ynh_app_setting_set $app multissid 1
-ynh_app_setting_set $app wifi_ssid "${wifi_ssid}"
-ynh_app_setting_set $app wifi_secure 1
-ynh_app_setting_set $app wifi_passphrase "${wifi_passphrase}"
-ynh_app_setting_set $app wifi_device "${wifi_device}"
-ynh_app_setting_set $app wifi_channel 6
-ynh_app_setting_set $app ip6_addr "${ip6_addr}"
-ynh_app_setting_set $app ip6_firewall 1
-ynh_app_setting_set $app ip6_net "${ip6_net}"
-ynh_app_setting_set $app ip6_dns0 2001:913::8
-ynh_app_setting_set $app ip6_dns1 2001:910:800::12
-ynh_app_setting_set $app ip4_dns0 80.67.188.188
-ynh_app_setting_set $app ip4_dns1 80.67.169.12
-ynh_app_setting_set $app ip4_nat_prefix 10.0.242
-ynh_app_setting_set $app vpnclient no
-ynh_app_setting_set $app service_name $service_name
+ynh_app_setting_set --app=$app --key=multissid --value=1
+ynh_app_setting_set --app=$app --key=wifi_ssid --value="${wifi_ssid}"
+ynh_app_setting_set --app=$app --key=wifi_secure --value=1
+ynh_app_setting_set --app=$app --key=wifi_passphrase --value="${wifi_passphrase}"
+ynh_app_setting_set --app=$app --key=wifi_device --value="${wifi_device}"
+ynh_app_setting_set --app=$app --key=wifi_channel --value=6
+ynh_app_setting_set --app=$app --key=ip6_addr --value="${ip6_addr}"
+ynh_app_setting_set --app=$app --key=ip6_firewall --value=1
+ynh_app_setting_set --app=$app --key=ip6_net --value="${ip6_net}"
+ynh_app_setting_set --app=$app --key=ip6_dns0 --value=2001:913::8
+ynh_app_setting_set --app=$app --key=ip6_dns1 --value=2001:910:800::12
+ynh_app_setting_set --app=$app --key=ip4_dns0 --value=80.67.188.188
+ynh_app_setting_set --app=$app --key=ip4_dns1 --value=80.67.169.12
+ynh_app_setting_set --app=$app --key=ip4_nat_prefix --value=10.0.242
+ynh_app_setting_set --app=$app --key=vpnclient --value=no
+ynh_app_setting_set --app=$app --key=service_name --value=$service_name
 
 if [[ -z $wifi_device ]]; then
-  ynh_app_setting_set $app service_enabled 0
+  ynh_app_setting_set --app=$app --key=service_enabled --value=0
   wifi_device=none
 else
-  ynh_app_setting_set $app service_enabled 1
+  ynh_app_setting_set --app=$app --key=service_enabled --value=1
 fi
 
 #=================================================
 # COPY CONFIGS
 #=================================================
+ynh_script_progression --message="Copying configuration..."
 
 mkdir -pm 0755 /etc/dnsmasq.dhcpd/
 chown root: /etc/dnsmasq.dhcpd/
@@ -247,11 +243,14 @@ install -b -o root -g root -m 0644 ../conf/dnsmasq_dhcpdv4.conf.tpl /etc/dnsmasq
 
 # Copy init script
 install -o root -g root -m 0755 ../conf/$service_name /usr/local/bin/
+ynh_replace_string --match_string="__PHPVERSION__" --replace_string="${phpversion}" --target_file="/usr/local/bin/$service_name"
 
 #=================================================
 # COPY WEB SOURCES
 #=================================================
+ynh_script_progression --message="Copy web sources..."
 
+ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 mkdir -pm 0755 ${final_path}/
 cp -a ../sources/* ${final_path}/
 
@@ -262,32 +261,34 @@ find ${final_path}/ -type d -exec chmod +x {} \;
 #=================================================
 # FIX CONFIGS
 #=================================================
+ynh_script_progression --message="Fix config..."
 
 ## hostapd
-ynh_replace_string "^DAEMON_CONF=$" "&/etc/hostapd/hostapd.conf" /etc/init.d/hostapd
+ynh_replace_string --match_string="^DAEMON_CONF=$" --replace_string="&/etc/hostapd/hostapd.conf" --target_file=/etc/init.d/hostapd
 # We also need to put this in /etc/default/hostapd because on some setup
 # like RPi, the version of hostapd is different and /etc/init.d/hostapd
 # isnt used ... instead the service is "pure systemd" ...
 echo "DAEMON_CONF=/etc/hostapd/hostapd.conf" > /etc/default/hostapd
 
 # Fix sources
-ynh_replace_string "__PATH__" "${path_url}" "$final_path/config.php"
+ynh_replace_string --match_string="__PATH__" --replace_string="${path_url}" --target_file="$final_path/config.php"
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM
 #=================================================
+ynh_script_progression --message="Storing the config file checksum..."
 
 # Calculate and store the config file checksum into the app settings
-ynh_store_file_checksum "$final_path/config.php"
-ynh_store_file_checksum "/etc/init.d/hostapd"
+ynh_store_file_checksum --file="$final_path/config.php"
+ynh_store_file_checksum --file="/etc/init.d/hostapd"
 
 #=================================================
 # SETUP SYSTEMD
 #=================================================
-ynh_print_info "Configuring a systemd service..."
+ynh_script_progression --message="Configuring a systemd service..."
 
 # Create a dedicated systemd config
-ynh_add_systemd_config $service_name
+ynh_add_systemd_config --service=$service_name
 
 # Set default inits
 # The boot order of these services are important, so they are disabled by default
@@ -296,14 +297,6 @@ systemctl disable hostapd
 systemctl stop hostapd
 systemctl unmask hostapd # On some system e.g. RPi, for some reason hostapd is masked after install ...
 
-#=================================================
-# RELOAD NGINX AND PHP-FPM
-#=================================================
-ynh_print_info "Reloading nginx web server..."
-
-systemctl restart php7.0-fpm
-systemctl reload nginx
-
 # Remove IPv6 address set if there is a VPN installed
 if [[ $ip6_addr != none ]]; then
   if ip -6 address show dev tun0 2> /dev/null | grep -q "${ip6_addr}/"; then
@@ -311,19 +304,35 @@ if [[ $ip6_addr != none ]]; then
   fi
 fi
 
-# register the service
-yunohost service add $service_name --description "Creates a Wi-Fi access point" --need_lock
+#=================================================
+# INTEGRATE SERVICE IN YUNOHOST
+#=================================================
+ynh_script_progression --message="Integrating service in YunoHost..."
 
-# enable and start the service if device is present
+yunohost service add $service_name --description "Creates a Wi-Fi access point" --log_type "systemd" --need_lock
+
+#=================================================
+# START SYSTEMD SERVICE
+#=================================================
+ynh_script_progression --message="Starting a systemd service..."
+
+# Start a systemd service if device is present
 if [[ $wifi_device == none ]]; then
   echo "WARNING: Wifi Hotspot is not started because no wifi device was found (please, check the web admin)" >&2
 else
-  yunohost service enable $service_name
-  yunohost service start $service_name
+  ynh_systemd_action --service_name=$service_name --action="start" --log_path=systemd #--line_match="Started YunoHost Wifi Hotspot"
 fi
+
+#=================================================
+# RELOAD NGINX AND PHP-FPM
+#=================================================
+ynh_script_progression --message="Reloading nginx web server..."
+
+ynh_systemd_action --service_name=php$phpversion-fpm --action=reload
+ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info "Installation of $app completed"
+ynh_script_progression --message="Installation of $app completed"

--- a/scripts/prerequisites
+++ b/scripts/prerequisites
@@ -4,5 +4,5 @@
 systemctl is-active dnsmasq &> /dev/null
 
 if [[ $? -ne 0 ]]; then
-  ynh_die "You need to enable dnsmasq instead of bind9 (apt-get remove bind9 && systemctl start dnsmasq)"
+  ynh_die --message="You need to enable dnsmasq instead of bind9 (apt-get remove bind9 && systemctl start dnsmasq)"
 fi

--- a/scripts/remove
+++ b/scripts/remove
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #=================================================
-# GENERIC STARTING
+# GENERIC START
 #=================================================
 # IMPORT GENERIC HELPERS
 #=================================================
@@ -29,24 +29,25 @@ source /usr/share/yunohost/helpers
 #=================================================
 # LOAD SETTINGS
 #=================================================
+ynh_script_progression --message="Loading installation settings..."
 
 app=$YNH_APP_INSTANCE_NAME
 
-domain=$(ynh_app_setting_get $app domain)
-firmware_nonfree=$(ynh_app_setting_get $app firmware_nonfree)
-service_name=$(ynh_app_setting_get $app service_name)
-final_path=$(ynh_app_setting_get $app final_path)
+domain=$(ynh_app_setting_get --app=$app --key=domain)
+firmware_nonfree=$(ynh_app_setting_get --app=$app --key=firmware_nonfree)
+service_name=$(ynh_app_setting_get --app=$app --key=service_name)
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
 #=================================================
 # STANDARD REMOVE
 #=================================================
-# REMOVE SERVICE FROM ADMIN PANEL
+# REMOVE SERVICE INTEGRATION IN YUNOHOST
 #=================================================
 
-# Remove a service from the admin panel, added by `yunohost service add`
+# Remove the service from the list of services known by Yunohost (added from `yunohost service add`)
 if yunohost service status $service_name >/dev/null 2>&1
 then
-	ynh_print_info "Removing $app service"
+	ynh_script_progression --message="Removing $app service"
 	yunohost service stop $service_name
 	yunohost service remove $service_name
 fi
@@ -54,15 +55,15 @@ fi
 #=================================================
 # STOP AND REMOVE SERVICE
 #=================================================
-ynh_print_info "Stopping and removing the systemd service"
+ynh_script_progression --message="Stopping and removing the systemd service..."
 
 # Remove the dedicated systemd config
-ynh_remove_systemd_config $service_name
+ynh_remove_systemd_config --service=$service_name
 
 #=================================================
 # REMOVE DEPENDENCIES
 #=================================================
-ynh_print_info "Removing dependencies"
+ynh_script_progression --message="Removing dependencies..."
 
 # Remove metapackage and its dependencies
 ynh_remove_app_dependencies
@@ -70,47 +71,47 @@ ynh_remove_app_dependencies
 #=================================================
 # REMOVE APP MAIN DIR
 #=================================================
-ynh_print_info "Removing app main directory"
+ynh_script_progression --message="Removing app main directory..."
 
 # Remove the app directory securely
-ynh_secure_remove "$final_path"
+ynh_secure_remove --file="$final_path"
 
-ynh_secure_remove /usr/local/bin/$service_name
+ynh_secure_remove --file="/usr/local/bin/$service_name"
 
-ynh_secure_remove "/usr/local/bin/iw_multissid"
-ynh_secure_remove "/usr/local/bin/iw_devices"
-ynh_secure_remove "/usr/local/bin/iw_ssids"
-ynh_secure_remove "/usr/local/bin/ipv6_expanded"
-ynh_secure_remove "/usr/local/bin/ipv6_compressed"
+ynh_secure_remove --file="/usr/local/bin/iw_multissid"
+ynh_secure_remove --file="/usr/local/bin/iw_devices"
+ynh_secure_remove --file="/usr/local/bin/iw_ssids"
+ynh_secure_remove --file="/usr/local/bin/ipv6_expanded"
+ynh_secure_remove --file="/usr/local/bin/ipv6_compressed"
 
-ynh_secure_remove "/etc/sudoers.d/${app}_ynh"
+ynh_secure_remove --file="/etc/sudoers.d/${app}_ynh"
 
 for FILE in $(ls /tmp/.ynh-hotspot-* 2>/dev/null)
 do
-    ynh_secure_remove "$FILE"
+    ynh_secure_remove --file="$FILE"
 done
 
 # Remove confs
-ynh_secure_remove "/etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl"
-ynh_secure_remove "/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
+ynh_secure_remove --file="/etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl"
+ynh_secure_remove --file="/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
 for FILE in $(ls /etc/hostapd/hostapd.conf{.tpl?,} 2>/dev/null)
 do
-    ynh_secure_remove "$FILE"
+    ynh_secure_remove --file="$FILE"
 done
 
 # Remove packages
 if [[ $firmware_nonfree -eq 0 ]]; then
   # Remove free firmwares
   if ! dpkg -l firmware-atheros &> /dev/null; then
-    ynh_secure_remove /lib/firmware/htc_7010.fw
-    ynh_secure_remove /lib/firmware/htc_9271.fw
+    ynh_secure_remove --file="/lib/firmware/htc_7010.fw"
+    ynh_secure_remove --file="/lib/firmware/htc_9271.fw"
   fi
 fi
 
 #=================================================
 # REMOVE NGINX CONFIGURATION
 #=================================================
-ynh_print_info "Removing nginx web server configuration"
+ynh_script_progression --message="Removing nginx web server configuration..."
 
 # Remove the dedicated nginx config
 ynh_remove_nginx_config
@@ -118,7 +119,7 @@ ynh_remove_nginx_config
 #=================================================
 # REMOVE PHP-FPM CONFIGURATION
 #=================================================
-ynh_print_info "Removing php-fpm configuration"
+ynh_script_progression --message="Removing php-fpm configuration..."
 
 # Remove the dedicated php-fpm config
 ynh_remove_fpm_config
@@ -129,14 +130,14 @@ ynh_remove_fpm_config
 
 if yunohost firewall list | grep -q "\- 547$"
 then
-	ynh_print_info "Closing port 547"
+	ynh_script_progression --message="Closing port 547"
 	ynh_exec_warn_less yunohost firewall disallow TCP 547
 fi
 
 
 if yunohost firewall list | grep -q "\- 67$"
 then
-	ynh_print_info "Closing port 67"
+	ynh_script_progression --message="Closing port 67"
 	ynh_exec_warn_less yunohost firewall disallow TCP 67
 fi
 
@@ -145,13 +146,13 @@ fi
 #=================================================
 # REMOVE DEDICATED USER
 #=================================================
-ynh_print_info "Removing the dedicated system user"
+ynh_script_progression --message="Removing the dedicated system user..."
 
 # Delete a system user
-ynh_system_user_delete $app
+ynh_system_user_delete --username=$app
 
 #=================================================
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info "Removal of $app completed"
+ynh_script_progression --message="Removal of $app completed"

--- a/scripts/restore
+++ b/scripts/restore
@@ -6,6 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+#Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
@@ -19,40 +20,42 @@ ynh_abort_if_errors
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_print_info "Loading settings..."
+ynh_script_progression --message="Loading settings..."
 
 app=$YNH_APP_INSTANCE_NAME
 
-domain=$(ynh_app_setting_get $app domain)
-path_url=$(ynh_app_setting_get $app path)
-final_path=$(ynh_app_setting_get $app final_path)
-firmware_nonfree=$(ynh_app_setting_get $app firmware_nonfree)
-service_name=$(ynh_app_setting_get $app service_name)
+domain=$(ynh_app_setting_get --app=$app --key=domain)
+path_url=$(ynh_app_setting_get --app=$app --key=path)
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+firmware_nonfree=$(ynh_app_setting_get --app=$app --key=firmware_nonfree)
+service_name=$(ynh_app_setting_get --app=$app --key=service_name)
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
-ynh_print_info "Validating restoration parameters..."
+ynh_script_progression --message="Validating restoration parameters..."
 
-ynh_webpath_available $domain $path_url \
-	|| ynh_die "Path not available: ${domain}${path_url}"
+ynh_webpath_available --domain=$domain --path_url=$path_url \
+	|| ynh_die --message="Path not available: ${domain}${path_url}"
 test ! -d $final_path \
-	|| ynh_die "There is already a directory: $final_path "
+	|| ynh_die --message="There is already a directory: $final_path "
 
 #=================================================
 # STANDARD RESTORATION STEPS
 #=================================================
 # RESTORE THE NGINX CONFIGURATION
 #=================================================
+ynh_script_progression --message="Restoring the nginx configuration..."
 
-ynh_restore_file "/etc/nginx/conf.d/$domain.d/$app.conf"
+ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
 # RESTORE THE APP MAIN DIR
 #=================================================
-ynh_print_info "Restoring the app main directory..."
+ynh_script_progression --message="Restoring the app main directory..."
 
-ynh_restore_file "$final_path"
+ynh_restore_file --origin_path="$final_path"
 
 if [[ $firmware_nonfree -eq 1 ]]; then
   # check if non-free is set on sources.list
@@ -64,40 +67,41 @@ if [[ $firmware_nonfree -eq 1 ]]; then
 else
   packages=$free_packages
 
-  ynh_restore_file "/lib/firmware/htc_7010.fw"
-  ynh_restore_file "/lib/firmware/htc_9271.fw"
+  ynh_restore_file --origin_path="/lib/firmware/htc_7010.fw"
+  ynh_restore_file --origin_path="/lib/firmware/htc_9271.fw"
 fi
 
-ynh_restore_file "/etc/sudoers.d/${app}_ynh"
+ynh_restore_file --origin_path="/etc/sudoers.d/${app}_ynh"
 
-ynh_restore_file "/usr/local/bin/iw_multissid"
-ynh_restore_file "/usr/local/bin/iw_devices"
-ynh_restore_file "/usr/local/bin/iw_ssids"
-ynh_restore_file "/usr/local/bin/ipv6_expanded"
-ynh_restore_file "/usr/local/bin/ipv6_compressed"
+ynh_restore_file --origin_path="/usr/local/bin/iw_multissid"
+ynh_restore_file --origin_path="/usr/local/bin/iw_devices"
+ynh_restore_file --origin_path="/usr/local/bin/iw_ssids"
+ynh_restore_file --origin_path="/usr/local/bin/ipv6_expanded"
+ynh_restore_file --origin_path="/usr/local/bin/ipv6_compressed"
 
 for FILE in $(ls /etc/hostapd/hostapd.conf{.tpl?,} 2>/dev/null)
 do
-    ynh_restore_file "$FILE"
+    ynh_restore_file --origin_path="$FILE"
 done
-ynh_restore_file "/etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl"
-ynh_restore_file "/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
+ynh_restore_file --origin_path="/etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl"
+ynh_restore_file --origin_path="/etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl"
 
-ynh_restore_file  "/usr/local/bin/$service_name"
+ynh_restore_file --origin_path="/usr/local/bin/$service_name"
 
-ynh_restore_file "/etc/init.d/hostapd"
+ynh_restore_file --origin_path="/etc/init.d/hostapd"
 
 #=================================================
 # RECREATE THE DEDICATED USER
 #=================================================
-ynh_print_info "Recreating the dedicated system user..."
+ynh_script_progression --message="Recreating the dedicated system user..."
 
 # Create the dedicated user (if not existing)
-ynh_system_user_create $app
+ynh_system_user_create --username=$app
 
 #=================================================
 # RESTORE USER RIGHTS
 #=================================================
+ynh_script_progression --message="Restoring user rights..."
 
 # Restore permissions on app files
 chown -R $app: $final_path
@@ -105,15 +109,16 @@ chown -R $app: $final_path
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION
 #=================================================
+ynh_script_progression --message="Restoring PHP-FPM configuration..."
 
-ynh_restore_file "/etc/php/7.0/fpm/pool.d/$app.conf"
+ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 
 #=================================================
 # SPECIFIC RESTORATION
 #=================================================
 # REINSTALL DEPENDENCIES
 #=================================================
-ynh_print_info "Reinstalling dependencies..."
+ynh_script_progression --message="Reinstalling dependencies..."
 
 # Define and install dependencies
 ynh_install_app_dependencies "$pkg_dependencies" "$packages"
@@ -121,29 +126,51 @@ ynh_install_app_dependencies "$pkg_dependencies" "$packages"
 #=================================================
 # RESTORE SYSTEMD
 #=================================================
-ynh_print_info "Restoring the systemd configuration..."
+ynh_script_progression --message="Restoring the systemd configuration..."
 
-ynh_restore_file "/etc/systemd/system/$service_name.service"
+ynh_restore_file --origin_path="/etc/systemd/system/$service_name.service"
 systemctl enable $service_name.service
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
+# INTEGRATE SERVICE IN YUNOHOST
 #=================================================
+ynh_script_progression --message="Integrating service in YunoHost..."
 
-yunohost service add $service_name --description "Creates a Wi-Fi access point" --need_lock
+yunohost service add $service_name --description "Creates a Wi-Fi access point" --log_type "systemd" --need_lock
+
+#=================================================
+# START SYSTEMD SERVICE
+#=================================================
+ynh_script_progression --message="Starting a systemd service..."
+
+wifi_device=$(bash ../settings/conf/iw_devices | awk -F\| '{ print $1 }')
+
+if [[ -z $wifi_device ]]; then
+  ynh_app_setting_set --app=$app --key=service_enabled --value=0
+  wifi_device=none
+else
+  ynh_app_setting_set --app=$app --key=service_enabled --value=1
+fi
+
+# Start a systemd service if device is present
+if [[ $wifi_device == none ]]; then
+  echo "WARNING: Wifi Hotspot is not started because no wifi device was found (please, check the web admin)" >&2
+else
+  ynh_systemd_action --service_name=$service_name --action="start" --log_path=systemd #--line_match="Started YunoHost Wifi Hotspot"
+fi
 
 #=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX AND PHP-FPM
 #=================================================
-ynh_print_info "Reloading nginx web server and php-fpm..."
+ynh_script_progression --message="Reloading nginx web server and php-fpm..."
 
-systemctl restart php7.0-fpm
-systemctl reload nginx
+ynh_systemd_action --service_name=php$phpversion-fpm --action=reload
+ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info "Restoration completed for $app"
+ynh_script_progression --message="Restoration completed for $app"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -12,32 +12,40 @@ source /usr/share/yunohost/helpers
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_print_info "Loading installation settings..."
+ynh_script_progression --message="Loading installation settings..."
 
 app=$YNH_APP_INSTANCE_NAME
 
-domain=$(ynh_app_setting_get $app domain)
-path_url=$(ynh_app_setting_get $app path)
-final_path=$(ynh_app_setting_get $app final_path)
-firmware_nonfree=$(ynh_app_setting_get $app firmware_nonfree)
-service_name=$(ynh_app_setting_get $app service_name)
+domain=$(ynh_app_setting_get --app=$app --key=domain)
+path_url=$(ynh_app_setting_get --app=$app --key=path)
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+firmware_nonfree=$(ynh_app_setting_get --app=$app --key=firmware_nonfree)
+service_name=$(ynh_app_setting_get --app=$app --key=service_name)
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+
+#=================================================
+# CHECK VERSION
+#=================================================
+ynh_script_progression --message="Checking version..."
+
+upgrade_type=$(ynh_check_app_version_changed)
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
-ynh_print_info "Ensuring downward compatibility..."
+ynh_script_progression --message="Ensuring downward compatibility..."
 
 # If final_path doesn't exist, create it
-if [ -z $final_path ]; then
+if [ -z "$final_path" ]; then
 	final_path=/var/www/$app
-	ynh_app_setting_set $app final_path $final_path
+	ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 fi
 
 if [ -d /var/www/wifiadmin/ ]; then
 	mv /var/www/wifiadmin $final_path
-	mv /etc/php/7.0/fpm/pool.d/wifiadmin.conf /etc/php/7.0/fpm/pool.d/$app.conf
-	ynh_replace_string "wifiadmin" "$app" /etc/php/7.0/fpm/pool.d/$app.conf
-	systemctl reload php7.0-fpm
+	mv /etc/php/7.0/fpm/pool.d/wifiadmin.conf /etc/php/$phpversion/fpm/pool.d/$app.conf
+	ynh_replace_string --match_string="wifiadmin" --replace_string="$app" --target_file=/etc/php/$phpversion/fpm/pool.d/$app.conf
+	ynh_systemd_action --service_name=php$phpversion-fpm --action=reload
 fi
 
 if [ $firmware_nonfree = "yes" ]; then
@@ -56,7 +64,7 @@ fi
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
-ynh_print_info "Backing up the app before upgrading (may take a while)..."
+ynh_script_progression --message="Backing up the app before upgrading (may take a while)..."
 
 # Backup the current version of the app
 ynh_backup_before_upgrade
@@ -72,22 +80,33 @@ ynh_abort_if_errors
 #=================================================
 
 # Normalize the URL path syntax
-path_url=$(ynh_normalize_url_path $path_url)
+path_url=$(ynh_normalize_url_path --path_url=$path_url)
 
 #=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
+# STOP SYSTEMD SERVICE
+#=================================================
+ynh_script_progression --message="Stopping a systemd service..."
+
+ynh_systemd_action --service_name=$service_name --action="stop" --log_path=systemd #--line_match="Started YunoHost Wifi Hotspot"
+
+#=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
-ynh_print_info "Upgrading source files..."
 
-# Download, check integrity, uncompress and patch the source from app.src
-cp -a ../sources/* ${final_path}/
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+	ynh_script_progression --message="Upgrading source files..."
+
+	# Download, check integrity, uncompress and patch the source from app.src
+	cp -a ../sources/* ${final_path}/
+fi
 
 #=================================================
 # NGINX CONFIGURATION
 #=================================================
-ynh_print_info "Upgrading nginx web server configuration..."
+ynh_script_progression --message="Upgrading nginx web server configuration..."
 
 # Create a dedicated nginx config
 ynh_add_nginx_config
@@ -95,7 +114,7 @@ ynh_add_nginx_config
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
-ynh_print_info "Upgrading dependencies..."
+ynh_script_progression --message="Upgrading dependencies..."
 
 if [[ $firmware_nonfree -eq 1 ]]; then
   packages=$nonfree_packages
@@ -108,15 +127,15 @@ ynh_install_app_dependencies "$pkg_dependencies" "$packages"
 #=================================================
 # CREATE DEDICATED USER
 #=================================================
-ynh_print_info "Making sure dedicated system user exists..."
+ynh_script_progression --message="Making sure dedicated system user exists..."
 
 # Create a dedicated user (if not existing)
-ynh_system_user_create $app
+ynh_system_user_create --username=$app
 
 #=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
-ynh_print_info "Upgrading php-fpm configuration..."
+ynh_script_progression --message="Upgrading php-fpm configuration..."
 
 # Create a dedicated php-fpm config
 ynh_add_fpm_config
@@ -124,32 +143,45 @@ ynh_add_fpm_config
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
-# FIX CONFIGS
+# COPY CONFIGS
 #=================================================
+ynh_script_progression --message="Copying configuration..."
 
-### And create a backup of this file if the checksum is different. So the file will be backed up if the admin had modified it.
-ynh_backup_if_checksum_is_different "$final_path/config.php"
-ynh_replace_string "__PATH__" "${path_url}" "$final_path/config.php"
+mkdir -pm 0755 /etc/dnsmasq.dhcpd/
+chown root: /etc/dnsmasq.dhcpd/
+
+install -b -o root -g root -m 0644 ../conf/hostapd.conf.tpl? /etc/hostapd/
+install -b -o root -g root -m 0644 ../conf/dnsmasq_dhcpdv6.conf.tpl /etc/dnsmasq.dhcpd/dhcpdv6.conf.tpl
+install -b -o root -g root -m 0644 ../conf/dnsmasq_dhcpdv4.conf.tpl /etc/dnsmasq.dhcpd/dhcpdv4.conf.tpl
+
+# Copy init script
+install -o root -g root -m 0755 ../conf/$service_name /usr/local/bin/
+ynh_replace_string --match_string="__PHPVERSION__" --replace_string="${phpversion}" --target_file="/usr/local/bin/$service_name"
+
+#=================================================
+# MODIFY A CONFIG FILE
+#=================================================
+ynh_script_progression --message="Modifying a config file..."
+
+ynh_backup_if_checksum_is_different --file="$final_path/config.php"
+ynh_replace_string --match_string="__PATH__" --replace_string="${path_url}" --target_file="$final_path/config.php"
 # Recalculate and store the checksum of the file for the next upgrade.
-ynh_store_file_checksum "$final_path/config.php"
+ynh_store_file_checksum --file="$final_path/config.php"
 
 #=================================================
 # SETUP SYSTEMD
 #=================================================
-ynh_print_info "Upgrading systemd configuration..."
+ynh_script_progression --message="Upgrading systemd configuration..."
 
 # Create a dedicated systemd config
-ynh_add_systemd_config $service_name
-
-# Make sure that the yunohost service has a description and need-lock enabled
-yunohost service add $service_name --description "Creates a Wi-Fi access point" --need_lock
-yunohost service start $service_name
+ynh_add_systemd_config --service=$service_name
 
 #=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SECURE FILES AND DIRECTORIES
 #=================================================
+ynh_script_progression --message="Securing files and directories..."
 
 # Set permissions on app files
 chown -R $app: ${final_path}/
@@ -157,15 +189,42 @@ chmod -R 0644 ${final_path}/*
 find ${final_path}/ -type d -exec chmod +x {} \;
 
 #=================================================
+# INTEGRATE SERVICE IN YUNOHOST
+#=================================================
+ynh_script_progression --message="Integrating service in YunoHost..."
+
+yunohost service add $service_name --description "Creates a Wi-Fi access point" --log_type "systemd" --need_lock
+
+#=================================================
+# START SYSTEMD SERVICE
+#=================================================
+ynh_script_progression --message="Starting a systemd service..."
+
+wifi_device=$(bash ../conf/iw_devices | awk -F\| '{ print $1 }')
+
+if [[ -z $wifi_device ]]; then
+  ynh_app_setting_set --app=$app --key=service_enabled --value=0
+  wifi_device=none
+else
+  ynh_app_setting_set --app=$app --key=service_enabled --value=1
+fi
+
+# Start a systemd service if device is present
+if [[ $wifi_device == none ]]; then
+  echo "WARNING: Wifi Hotspot is not started because no wifi device was found (please, check the web admin)" >&2
+else
+  ynh_systemd_action --service_name=$service_name --action="start" --log_path=systemd #--line_match="Started YunoHost Wifi Hotspot"
+fi
+
+#=================================================
 # RELOAD NGINX
 #=================================================
-ynh_print_info "Reloading nginx web server..."
+ynh_script_progression --message="Reloading nginx web server..."
 
-systemctl restart php7.0-fpm
-systemctl reload nginx
+ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info "Upgrade of $app completed"
+ynh_script_progression --message="Upgrade of $app completed"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -35,6 +35,11 @@ upgrade_type=$(ynh_check_app_version_changed)
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..."
 
+if [ -z $phpversion ]; then
+	phpversion=7.0
+	ynh_app_setting_set --app=$app --key=phpversion --value=$phpversion
+fi
+
 # If final_path doesn't exist, create it
 if [ -z "$final_path" ]; then
 	final_path=/var/www/$app
@@ -50,15 +55,15 @@ fi
 
 if [ $firmware_nonfree = "yes" ]; then
 	firmware_nonfree=1
-	ynh_app_setting_set $app firmware_nonfree $firmware_nonfree
+	ynh_app_setting_set --app=$app --key=firmware_nonfree --value=$firmware_nonfree
 elif [ $firmware_nonfree = "no" ]; then
 	firmware_nonfree=0
-	ynh_app_setting_set $app firmware_nonfree $firmware_nonfree
+	ynh_app_setting_set --app=$app --key=firmware_nonfree --value=$firmware_nonfree
 fi
 
 if [ -z $service_name ]; then
 	service_name="ynh-hotspot"
-	ynh_app_setting_set $app service_name $service_name
+	ynh_app_setting_set --app=$app --key=service_name --value=$service_name
 fi
 
 #=================================================
@@ -139,6 +144,7 @@ ynh_script_progression --message="Upgrading php-fpm configuration..."
 
 # Create a dedicated php-fpm config
 ynh_add_fpm_config
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem
- *Fix upgrade for buster:*

## Solution
- *Apply example_ynh*
- *On buster `hostapd` fails to start if there is no wifi interface.
and if `hostapd` service fails, `ynh-hotspot` service fails too
and during upgrde, there was: 
https://github.com/labriqueinternet/hotspot_ynh/blob/ec919eb58fdc9c358ddbe17558874ae968a7f527/scripts/upgrade#L146*

that make the upgrade fails

So I added the same `$wifi_device` detection in the upgrade and the restore script

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/hotspot_ynh%20PR63%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/hotspot_ynh%20PR63%20(yalh76)/)  

Other CI results for Revision: b4f05d6864bf91a74899e396a9ca08aba9a1f4e3 :
### Stretch
![image](https://user-images.githubusercontent.com/30271971/83761258-59bafd80-a676-11ea-802f-7618177cdc82.png)


### Buster
![image](https://user-images.githubusercontent.com/30271971/83761223-50319580-a676-11ea-811b-aeb737ce2dfc.png)

