### PR TITLE
No device defined

### DIFF
--- a/conf/ynh-hotspot
+++ b/conf/ynh-hotspot
@@ -337,6 +337,12 @@ case "$1" in
     elif [ "${ynh_service_enabled}" != "enabled" ]; then
       echo "Disabled service"
     else
+
+      if [ -z "${ynh_wifi_device}" ]; then
+        echo "[ERR] No wifi device selected. Make sure your wifi antenna is plugged-in / available and select it in the Hotspot admin"
+        exitcode=1
+      fi
+
       echo "[hotspot] Starting..."
       touch /tmp/.ynh-hotspot-started
 
@@ -485,6 +491,11 @@ case "$1" in
 
     if [ "${ynh_service_enabled}" != "enabled" ]; then
       echo "[ERR] Hotspot Service disabled"
+      exitcode=1
+    fi
+
+    if [ -z "${ynh_wifi_device}" ]; then
+      echo "[ERR] No wifi device selected. Make sure your wifi antenna is plugged-in / available and select it in the Hotspot admin"
       exitcode=1
     fi
 


### PR DESCRIPTION
Encountered a small bug where (with no antenna because testing inside a LXC ...) `systemctl status ynh-hotspot` reported : 

```
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: Retrieving Yunohost settings... OK
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: [hotspot] Starting...
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: Run hostapd
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: Device "" does not exist.
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: "" is invalid lladdr.
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: Job for hostapd.service failed because the control process exited with error code.
Sep 23 20:48:18 yolo.test ynh-hotspot[23060]: See "systemctl status hostapd.service" and "journalctl -xe" for details.
Sep 23 20:48:18 yolo.test systemd[1]: ynh-hotspot.service: Main process exited, code=exited, status=1/FAILURE
Sep 23 20:48:18 yolo.test systemd[1]: ynh-hotspot.service: Failed with result 'exit-code'.
Sep 23 20:48:18 yolo.test systemd[1]: Failed to start YunoHost Wifi Hotspot..
```

But it shouldn't try to start hostapd if no wifi device is defined in the first place ...