### PR TITLE
Enable IEEE 802.11n

### DIFF
--- a/conf/hostapd.conf
+++ b/conf/hostapd.conf
@@ -4,6 +4,7 @@ macaddr_acl=0
 auth_algs=1
 ignore_broadcast_ssid=0
 channel=__WIFI_CHANNEL__
+ieee80211n=1
 ssid=__WIFI_SSID__
 __SEC_COMMENT__wpa=2
 __SEC_COMMENT__wpa_passphrase=__WIFI_PASSPHRASE__


### PR DESCRIPTION
## Problem

I noticed that we could enable IEEE 802.11n, which gives better bandwidth on antennas that support it (I guess almost all antennas will support it nowadays)

## Solution

Enabling IEEE 802.11n in hostapd config.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
