### PR TITLE
Remove `firmware-atheros` from deps on armbian boards

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -66,7 +66,7 @@ ram.runtime = "50M"
             # if armbian-firmware is detected, we dont include ra-link which is known to conflict....
             # so is firmware-atheros apparently
             if dpkg --list | grep -q armbian-firmware; then
-                echo "irmware-realtek firmware-libertas atmel-firmware firmware-zd1211"
+                echo "firmware-realtek firmware-libertas atmel-firmware firmware-zd1211"
             else
                 echo "firmware-atheros firmware-realtek firmware-ralink firmware-libertas atmel-firmware firmware-zd1211"
             fi

--- a/manifest.toml
+++ b/manifest.toml
@@ -64,8 +64,9 @@ ram.runtime = "50M"
         # Proprietary USB Wireless Device firmwares, based on https://wiki.debian.org/WiFi#USB_Devices
         if [[ "$firmware_nonfree" -eq 1 ]]; then
             # if armbian-firmware is detected, we dont include ra-link which is known to conflict....
+            # so is firmware-atheros apparently
             if dpkg --list | grep -q armbian-firmware; then
-                echo "firmware-atheros firmware-realtek firmware-libertas atmel-firmware firmware-zd1211"
+                echo "irmware-realtek firmware-libertas atmel-firmware firmware-zd1211"
             else
                 echo "firmware-atheros firmware-realtek firmware-ralink firmware-libertas atmel-firmware firmware-zd1211"
             fi


### PR DESCRIPTION
## Problem

- https://forum.yunohost.org/t/impossible-installer-hotspot/42360

## Solution

- `firmware-atheros` evidently now ships bundled with `armbian-firmware`, remove from deps

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
