### PR TITLE
Detect debian distribution version

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -59,7 +59,7 @@ ram.runtime = "50M"
 
     [resources.apt.extras.nonfree]
     repo = "deb http://deb.debian.org/debian __YNH_DEBIAN_VERSION__ non-free-firmware"
-    key = "https://ftp-master.debian.org/keys/archive-key-__YNH_DEBIAN_ID__.asc"
+    key = "https://ftp-master.debian.org/keys/archive-key-__YNH_DEBIAN_VERSION_ID__.asc"
     packages_from_raw_bash = """
         # Proprietary USB Wireless Device firmwares, based on https://wiki.debian.org/WiFi#USB_Devices
         if [[ "$firmware_nonfree" -eq 1 ]]; then

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,11 +55,6 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = "sipcalc, hostapd, iw, kmod"
-    packages_from_raw_bash = '[[ "$firmware_nonfree" -eq 0 ]] && echo "firmware-ath9k-htc" || true'
-
-    [resources.apt.extras.nonfree]
-    repo = "deb http://deb.debian.org/debian __YNH_DEBIAN_VERSION__ non-free-firmware"
-    key = "https://ftp-master.debian.org/keys/archive-key-__YNH_DEBIAN_VERSION_ID__.asc"
     packages_from_raw_bash = """
         # Proprietary USB Wireless Device firmwares, based on https://wiki.debian.org/WiFi#USB_Devices
         if [[ "$firmware_nonfree" -eq 1 ]]; then
@@ -70,5 +65,5 @@ ram.runtime = "50M"
                 echo "firmware-atheros firmware-realtek firmware-ralink firmware-libertas atmel-firmware firmware-zd1211"
             fi
         else
-            echo " "
+            echo "firmware-ath9k-htc"
         fi"""

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,6 +55,10 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = "sipcalc, hostapd, iw, kmod"
+    packages_from_raw_bash = '[[ "$firmware_nonfree" -eq 0 ]] && echo "firmware-ath9k-htc" || true'
+
+    [resources.apt.extras.nonfree]
+    repo = "deb http://deb.debian.org/debian __YNH_DEBIAN_VERSION__ non-free-firmware"
     packages_from_raw_bash = """
         # Proprietary USB Wireless Device firmwares, based on https://wiki.debian.org/WiFi#USB_Devices
         if [[ "$firmware_nonfree" -eq 1 ]]; then
@@ -65,5 +69,5 @@ ram.runtime = "50M"
                 echo "firmware-atheros firmware-realtek firmware-ralink firmware-libertas atmel-firmware firmware-zd1211"
             fi
         else
-            echo "firmware-ath9k-htc"
+            echo " "
         fi"""

--- a/manifest.toml
+++ b/manifest.toml
@@ -58,8 +58,8 @@ ram.runtime = "50M"
     packages_from_raw_bash = '[[ "$firmware_nonfree" -eq 0 ]] && echo "firmware-ath9k-htc" || true'
 
     [resources.apt.extras.nonfree]
-    repo = "deb http://deb.debian.org/debian bullseye non-free"
-    key = "https://ftp-master.debian.org/keys/archive-key-11.asc"
+    repo = "deb http://deb.debian.org/debian __YNH_DEBIAN_VERSION__ non-free-firmware"
+    key = "https://ftp-master.debian.org/keys/archive-key-__YNH_DEBIAN_ID__.asc"
     packages_from_raw_bash = """
         # Proprietary USB Wireless Device firmwares, based on https://wiki.debian.org/WiFi#USB_Devices
         if [[ "$firmware_nonfree" -eq 1 ]]; then


### PR DESCRIPTION
## Problem

The debian ditribution for the non-free firmware repo is hardcoded in the manifest, and I noticed it was still in bullseye…

## Solution

Make use of the `__YNH_DEBIAN_VERSION__` et `__YNH_DEBIAN_ID__` undocumented variables (see https://github.com/YunoHost/issues/issues/2855 to document them)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
