### PR TITLE
Trixie: return non-empty choices list in config panel

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -64,7 +64,7 @@ get__wifi_device() {
     local unused_wifi_devices=$(unused_iw_devices)
     if [[ -z "${unused_wifi_devices}" ]]
     then
-        echo "choices: []"
+        echo "choices: ['']"
     else
         cat << EOF
 choices:

--- a/scripts/config
+++ b/scripts/config
@@ -64,6 +64,8 @@ get__wifi_device() {
     local unused_wifi_devices=$(unused_iw_devices)
     if [[ -z "${unused_wifi_devices}" ]]
     then
+        # We return a list with an empty string because config panel doesn't accept empty list anymore in Yunohost 13.
+        # This won't be displayed anyways, as the wifi device field is hidden when there is no antenna.
         echo "choices: ['']"
     else
         cat << EOF


### PR DESCRIPTION
## Problem

In Yunohost 13, we can't return an empty list for select field in config panel. We return such empty list when no wifi usb antenna is found.

## Solution

As we don't actually display such list when no antenna is found, we can simply return a list containing an empty string.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
