### PR TITLE
Configure dnsmasq listen interface for dns resolver on wifi device

### DIFF
--- a/conf/dnsmasq_dns_resolver.conf
+++ b/conf/dnsmasq_dns_resolver.conf
@@ -1,0 +1,2 @@
+# Wifi Hotspot app for YunoHost 
+interface=__WIFI_DEVICE__

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -65,3 +65,8 @@ function configure_dhcp()
     fi
 
 }
+
+function configure_dns_resolver()
+{
+    ynh_config_add --template="dnsmasq_dns_resolver.conf" --destination="/etc/dnsmasq.d/$app.conf"
+}

--- a/scripts/backup
+++ b/scripts/backup
@@ -13,6 +13,7 @@ ynh_print_info "Declaring files to be backed up..."
 ynh_backup "/etc/hostapd/$app/hostapd.conf" || true
 ynh_backup "/etc/dnsmasq.$app/dhcpdv6.conf" || true
 ynh_backup "/etc/dnsmasq.$app/dhcpdv4.conf" || true
+ynh_backup "/etc/dnsmasq.d/$app.conf" || true
 
 ynh_backup "/usr/local/bin/$service_name"
 

--- a/scripts/config
+++ b/scripts/config
@@ -193,6 +193,7 @@ ynh_app_config_apply() {
     if [[ "${service_enabled}" -eq 1 ]]; then
         configure_hostapd
         configure_dhcp
+        configure_dns_resolver
 
         # Start hotspot
         ynh_print_info "Starting hotspot service if needed"
@@ -202,6 +203,7 @@ ynh_app_config_apply() {
         ynh_safe_rm "/etc/hostapd/$app/hostapd.conf"
         ynh_safe_rm "/etc/dnsmasq.$app/dhcpdv4.conf"
         ynh_safe_rm "/etc/dnsmasq.$app/dhcpdv6.conf"
+        ynh_safe_rm "/etc/dnsmasq.d/$app.conf"
     fi
 
     # Restart dnsmasq to disable or enable dns resolution on dnsmasq for the wifi interface

--- a/scripts/install
+++ b/scripts/install
@@ -120,6 +120,7 @@ systemctl mask hostapd 2>&1
 if [[ -n "${wifi_device}" ]]; then
     configure_hostapd
     configure_dhcp
+	configure_dns_resolver
 
 	systemctl restart dnsmasq
 fi

--- a/scripts/remove
+++ b/scripts/remove
@@ -29,6 +29,7 @@ done
 
 # Remove confs
 ynh_safe_rm "/etc/dnsmasq.$app/"
+ynh_safe_rm "/etc/dnsmasq.d/$app.conf"
 ynh_safe_rm "/etc/hostapd/$app/"
 
 systemctl restart dnsmasq

--- a/scripts/restore
+++ b/scripts/restore
@@ -69,6 +69,8 @@ if [[ -z "${wifi_device:-}" ]]; then
 else
     configure_hostapd
     configure_dhcp
+    configure_dns_resolver
+    
 	ynh_app_setting_set --key=service_enabled --value=1
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -146,6 +146,8 @@ chown root: /etc/dnsmasq.$app/
 if [[ -n "${wifi_device:-}" ]]; then
     configure_hostapd
     configure_dhcp
+	configure_dns_resolver
+	
 	ynh_app_setting_set --key=service_enabled --value=1
 else
 	ynh_app_setting_set --key=service_enabled --value=0


### PR DESCRIPTION
## Problem

I noticed that the DNS resolver doesn't respond when we are connected to the wifi hotspot.
By default, dnsmasq listen on the loopback interface:
```
# cat /etc/dnsmasq.conf
domain-needed
expand-hosts
localise-queries

interface=lo

resolv-file=/etc/resolv.dnsmasq.conf
cache-size=256
```

## Solution

I'm configuring dnsmasq to listen on the wifi device's interface when we configure the hotspot. The additonal config file is stored in `/etc/dnsmasq.d`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
