### PR TITLE
improve pattern to detect usb wifi devices

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -33,7 +33,7 @@ function hot_reload_usb_wifi_cards()
 {
     modulesList="acx-mac80211 ar5523 ar9170usb at76c50x-usb at76_usb ath9k_htc carl9170 orinoco_usb p54usb prism2_usb r8712u r8192s_usb r8192u_usb rndis_wlan rt2500usb rt2800usb rt2870sta rt73usb rtl8187 rtl8192cu usb8xxx vt6656_stage zd1201 zd1211rw"
     modprobe --quiet --remove $modulesList || true
-    possibleUsbDevicesNeedingReload=$(dmesg | grep -Pio '(?<=usb )[0-9-]+(?=:.*firmware)' | sort | uniq)
+    possibleUsbDevicesNeedingReload=$(dmesg | grep -Pio '(?<=usb )[0-9-]+(?=:.*(FW|firmware))' | sort | uniq)
     for usbPath in $possibleUsbDevicesNeedingReload; do
         if [[ -f "/sys/bus/usb/devices/$usbPath/authorized" ]]; then
             echo "Try to reload driver for usb $usbPath" >&2


### PR DESCRIPTION
## Problem

The detection of wifi devices doesn't work on some system (for instance, on a amd64 running on trixie).

## Solution

In addition to looking for usb devices that contains the pattern `firmware` in `dmesg` logs, we look for devices containing `fw`. Here is an instance of `dmesg` log that matches this pattern:
```
usb 3-2: ath9k_htc: Transferred FW: ath9k_htc/htc_9271-1.4.0.fw, size: 51008
```

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
